### PR TITLE
Add Order server url as process env. Defaults to http://localhost:500…

### DIFF
--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -1147,6 +1147,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2155,11 +2160,11 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
+      "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "xmlhttprequest": {

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -16,7 +16,8 @@
     "openpgp": "^4.2.1",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",
-    "uuid4": "^1.0.0"
+    "uuid4": "^1.0.0",
+    "ws": "^7.0.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/api-server/server.js
+++ b/api-server/server.js
@@ -6,9 +6,11 @@ if (!process.env.PRIVATE_KEY || !process.env.MAINNET) {
   throw new Error('must set PRIVATE_KEY and MAINNET environment variables')
 }
 
+const ORDER_SERVER_URL = process.env.ORDER_SERVER_URL || 'http://localhost:5004/getOrder'
+
 const app = express()
 app.use(express.json())
-app.listen(5005, () => console.log('API client server listening on port 5005!'))
+app.listen(5005, () => console.log('API client server listening on port 5005! Order server url: ' + ORDER_SERVER_URL))
 
 const airswap = new AirSwap({
   privateKey: process.env.PRIVATE_KEY,
@@ -32,7 +34,7 @@ airswap.RPC_METHOD_ACTIONS.getOrder = msg => {
   params.makerAddress = airswap.wallet.address
   rp({
     method: 'POST',
-    uri: 'http://localhost:5004/getOrder',
+    uri: ORDER_SERVER_URL,
     json: true,
     body: params,
   }).then(orderParams => {


### PR DESCRIPTION
…4/getOrder.

This can be useful when running api server / order server in Docker containers where container name can be passed as order server host

Updated dependencies to avoid server start failure with error below
npm WARN isomorphic-ws@4.0.1 requires a peer of ws@* but none is installed. You must install peer dependencies yourself.